### PR TITLE
Moved shutdown() call.

### DIFF
--- a/elf/Versions
+++ b/elf/Versions
@@ -183,7 +183,6 @@ ld {
     lind_getpeername;
     lind_setsockopt;
     lind_getsockopt;
-    lind_shutdown;
     lind_select;
     lind_getifaddrs;
     lind_poll;

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -1021,7 +1021,7 @@ init_irt_table (void)
   __nacl_irt_getsockopt = nacl_irt_getsockopt_lind;
   __nacl_irt_setsockopt = nacl_irt_setsockopt_lind;
   __nacl_irt_socketpair = nacl_irt_socketpair_lind;
-  __nacl_irt_shutdown = nacl_irt_shutdown_lind;
+  __nacl_irt_shutdown = nacl_irt_shutdown;
   __nacl_irt_gethostname = nacl_irt_gethostname;
   __nacl_irt_getpid = nacl_irt_getpid;
   __nacl_irt_getppid = nacl_irt_getppid;

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -585,9 +585,9 @@ static int nacl_irt_recvfrom(int sockfd, void *buf, size_t len, int flags,
     return 0;
 }
 
-static int nacl_irt_shutdown_lind (int sockfd, int how)
+static int nacl_irt_shutdown (int sockfd, int how)
 {
-    int rv = lind_shutdown(sockfd, how);
+    int rv = NACL_SYSCALL (shutdown) (sockfd,how);
     if (rv < 0)
         return -rv;
     return 0;

--- a/sysdeps/nacl/lind_syscalls.c
+++ b/sysdeps/nacl/lind_syscalls.c
@@ -208,11 +208,7 @@ int lind_getsockopt (int sockfd, int level, int optname, socklen_t optlen, void 
     return NACL_SYSCALL(lind_api)(LIND_safe_net_getsockopt, 4, in_args, 1, out_args);
 }
 
-int lind_shutdown (int sockfd, int how)
-{
-    LindArg in_args[2] = {{AT_INT, sockfd, 0}, {AT_INT, how, 0}};
-    return NACL_SYSCALL(lind_api)(LIND_safe_net_shutdown, 2, in_args, 0, NULL);
-}
+
 
 int lind_select (int nfds, fd_set * readfds, fd_set * writefds, fd_set * exceptfds, const struct timeval *timeout, struct select_results *result)
 {

--- a/sysdeps/nacl/lind_syscalls.h
+++ b/sysdeps/nacl/lind_syscalls.h
@@ -44,7 +44,6 @@
 #define LIND_safe_net_getsockname       42
 #define LIND_safe_net_getsockopt        43
 #define LIND_safe_net_setsockopt        44
-#define LIND_safe_net_shutdown          45
 #define LIND_safe_net_select            46
 #define LIND_safe_net_getifaddrs        47
 #define LIND_safe_net_poll              48
@@ -116,7 +115,6 @@ int lind_getsockname (int sockfd, socklen_t addrlen_in, struct sockaddr * addr, 
 int lind_getpeername (int sockfd, socklen_t addrlen_in, struct sockaddr * addr, socklen_t * addrlen_out);
 int lind_setsockopt (int sockfd, int level, int optname, socklen_t optlen, const void *optval);
 int lind_getsockopt (int sockfd, int level, int optname, socklen_t optlen, void *optval);
-int lind_shutdown (int sockfd, int how);
 int lind_select (int nfds, fd_set * readfds, fd_set * writefds, fd_set * exceptfds, const struct timeval *timeout, struct select_results *result);
 int lind_getifaddrs (int ifaddrs_buf_siz, void *ifaddrs);
 int lind_poll (int nfds, int timeout, struct pollfd *fds_in, struct pollfd *fds_out);

--- a/sysdeps/nacl/nacl_syscalls.h
+++ b/sysdeps/nacl/nacl_syscalls.h
@@ -70,6 +70,7 @@
 #define NACL_sys_nanosleep              42
 #define NACL_sys_clock_getres           43
 #define NACL_sys_clock_gettime          44
+#define NACL_sys_shutdown               45
 
 /* 50-58 previously used for multimedia syscalls */
 
@@ -228,6 +229,8 @@ typedef int (*TYPE_nacl_clock_getres) (clockid_t clk_id,
                                        struct timespec *res);
 typedef int (*TYPE_nacl_clock_gettime) (clockid_t clk_id,
                                         struct timespec *tp);
+typedef int (*TYPE_nacl_shutdown) (int sockfd, int how);
+
 /* Don't use __attribute__((noreturn)) on this because we want the
    wrapper to handle it if the syscall does happen to return. */
 typedef void (*TYPE_nacl_exit) (int status);


### PR DESCRIPTION
Moved shutdown() call, should be working correctly.
To test it, add these two lines to serverclient.c after line 73 in unified_syscalls.

```
    shutdown(server_fd,SHUT_RDWR);
    printf("Shutdownsent\n");
```