### PR TITLE
Flock syscall

### DIFF
--- a/elf/Versions
+++ b/elf/Versions
@@ -158,6 +158,7 @@ ld {
     __nacl_irt_pwrite;
     __nacl_irt_unlink;
     __nacl_irt_link;
+    __nacl_irt_flock;
     lind_access;
     lind_xstat;
     lind_open;
@@ -191,7 +192,6 @@ ld {
     lind_geteuid;
     lind_getgid;
     lind_getegid;
-    lind_flock;
     lind_strace;
     lind_pipe;
     # Those are in the dynamic linker, but used by libc.so.

--- a/sysdeps/nacl/flock.c
+++ b/sysdeps/nacl/flock.c
@@ -28,7 +28,14 @@ __flock (fd, operation)
      int operation;
 {
 #warning compiling flock
-    SET_ERR_AND_RETURN(__nacl_irt_flock(fd, operation));
+    int result = __nacl_irt_flock(fd, operation);
+    if (result < 0) {
+        __set_errno (-result);
+        return -1;
+    }
+    else{
+    return result;
+    }
 }
 
 weak_alias (__flock, flock)

--- a/sysdeps/nacl/flock.c
+++ b/sysdeps/nacl/flock.c
@@ -27,15 +27,14 @@ __flock (fd, operation)
      int fd;
      int operation;
 {
-#warning compiling flock
-    int result = __nacl_irt_flock(fd, operation);
-    if (result < 0) {
-        __set_errno (-result);
-        return -1;
-    }
-    else{
-    return result;
-    }
+ int result = __nacl_irt_flock(fd, operation);
+ if (result < 0) {
+    __set_errno (-result);
+    return -1;
+ }
+ else{
+ return result;
+ }
 }
 
 weak_alias (__flock, flock)

--- a/sysdeps/nacl/flock.c
+++ b/sysdeps/nacl/flock.c
@@ -18,9 +18,7 @@
 
 #include <errno.h>
 #include <sys/file.h>
-#include "lind_strace.h"
-#include "lind_util.h"
-#include "lind_syscalls.h"
+#include <irt_syscalls.h>
 
 /* Apply or remove an advisory lock, according to OPERATION,
    on the file FD refers to.  */
@@ -30,7 +28,7 @@ __flock (fd, operation)
      int operation;
 {
 #warning compiling flock
-    SET_ERR_AND_RETURN(lind_flock(fd, operation));
+    SET_ERR_AND_RETURN(__nacl_irt_flock(fd, operation));
 }
 
 weak_alias (__flock, flock)

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -764,7 +764,7 @@ static int nacl_irt_recvmsg_lind (int sockfd, struct msghdr *msg,
 
 static int nacl_irt_flock (int fd, int operation)
 {
-  return -NACL_SYSCALL (flock) (fd, operation);
+  return NACL_SYSCALL (flock) (fd, operation);
 }
 
 void

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -442,6 +442,7 @@ int (*__nacl_irt_pipe2) (int pipedes[static 2], int flags);
 int (*__nacl_irt_execve) (char const *path, char *const *argv, char *const *envp);
 int (*__nacl_irt_execv) (char const *path, char *const *argv);
 int (*__nacl_irt_sigprocmask) (int how, const sigset_t *set, sigset_t *oset);
+int (*__nacl_irt_flock) (int fd, int operation);
 
 #include <lind_syscalls.h>
 size_t (*saved_nacl_irt_query)(const char *interface_ident, void *table, size_t tablesize);
@@ -761,6 +762,11 @@ static int nacl_irt_recvmsg_lind (int sockfd, struct msghdr *msg,
     return 0;
 }
 
+static int nacl_irt_flock (int fd, int operation)
+{
+  return -NACL_SYSCALL (flock) (fd, operation);
+}
+
 void
 init_irt_table (void)
 {
@@ -1042,6 +1048,7 @@ init_irt_table (void)
   __nacl_irt_execve = nacl_irt_execve;
   __nacl_irt_sigprocmask = nacl_irt_sigprocmask;
   __nacl_irt_lstat = nacl_irt_lstat;
+  __nacl_irt_flock = nacl_irt_flock;
 }
 
 size_t nacl_interface_query(const char *interface_ident,

--- a/sysdeps/nacl/irt_syscalls.h
+++ b/sysdeps/nacl/irt_syscalls.h
@@ -167,6 +167,7 @@ extern int (*__nacl_irt_pipe2) (int pipedes[static 2], int flags);
 extern int (*__nacl_irt_execve) (char const *path, char *const *argv, char *const *envp);
 extern int (*__nacl_irt_execv) (char const *path, char *const *argv);
 extern int (*__nacl_irt_sigprocmask) (int how, const sigset_t *set, sigset_t *oset);
+extern int (*__nacl_irt_flock) (int fd, int operation);
 
 #undef socklen_t
 

--- a/sysdeps/nacl/lind_syscalls.c
+++ b/sysdeps/nacl/lind_syscalls.c
@@ -353,12 +353,6 @@ int lind_getegid (gid_t * buf)
     return NACL_SYSCALL(lind_api)(LIND_safe_sys_getegid, 0, NULL, 1, out_args);
 }
 
-int lind_flock (int fd, int operation)
-{
-    LindArg in_args[2] = {{AT_INT, fd, 0}, {AT_INT, operation, 0}};
-    return NACL_SYSCALL(lind_api)(LIND_safe_fs_flock, 2, in_args, 0, NULL);
-}
-
 int lind_strace (const char* str)
 {
 #if 1

--- a/sysdeps/nacl/lind_syscalls.h
+++ b/sysdeps/nacl/lind_syscalls.h
@@ -52,7 +52,6 @@
 #define LIND_safe_sys_geteuid           51
 #define LIND_safe_sys_getgid            52
 #define LIND_safe_sys_getegid           53
-#define LIND_safe_fs_flock              54
 #define LIND_safe_fs_rename             55
 #define LIND_safe_net_epoll_create      56
 #define LIND_safe_net_epoll_ctl         57
@@ -123,7 +122,6 @@ int lind_getuid (uid_t * buf);
 int lind_geteuid (uid_t * buf);
 int lind_getgid (gid_t * buf);
 int lind_getegid (gid_t * buf);
-int lind_flock (int fd, int operation);
 int lind_strace (const char* str);
 int lind_epoll_create (int size);
 int lind_epoll_ctl (int epfd, int op, int fd, struct epoll_event *event);

--- a/sysdeps/nacl/nacl_syscalls.h
+++ b/sysdeps/nacl/nacl_syscalls.h
@@ -72,6 +72,7 @@
 #define NACL_sys_clock_gettime          44
 #define NACL_sys_shutdown               45
 
+#define NACL_sys_flock                  54
 /* 50-58 previously used for multimedia syscalls */
 
 #define NACL_sys_imc_makeboundsock      60
@@ -126,6 +127,7 @@
 #define NACL_sys_gethostname            125
 #define NACL_sys_pread                  126
 #define NACL_sys_pwrite                 127
+
 
 #define NACL_sys_chdir                  130
 #define NACL_sys_mkdir                  131
@@ -264,5 +266,7 @@ typedef int (*TYPE_nacl_pread) (int desc, void *buf, size_t count, off_t offset)
 typedef int (*TYPE_nacl_pwrite) (int desc, const void *buf, size_t count, off_t offset);
 
 typedef int (*TYPE_nacl_socket) (int domain, int type, int protocol);
+
+typedef int (*TYPE_nacl_flock (int fd, int operation));
 
 #endif

--- a/sysdeps/nacl/nacl_syscalls.h
+++ b/sysdeps/nacl/nacl_syscalls.h
@@ -267,6 +267,6 @@ typedef int (*TYPE_nacl_pwrite) (int desc, const void *buf, size_t count, off_t 
 
 typedef int (*TYPE_nacl_socket) (int domain, int type, int protocol);
 
-typedef int (*TYPE_nacl_flock (int fd, int operation));
+typedef int (*TYPE_nacl_flock) (int fd, int operation);
 
 #endif


### PR DESCRIPTION
A temporary request, might need review on an issue.
```
../sysdeps/nacl/irt_syscalls.c: In function ‘nacl_irt_flock’:
../sysdeps/nacl/irt_syscalls.c:767: error: cast specifies function type
```
Every other reference should be made correctly, trying to figure out the reason.

Edit: Culprit found (a misplaced paranthesis) and fixed.