### PR TITLE
Removed first call logistics from get[e][g/u]id.c

### DIFF
--- a/sysdeps/nacl/getegid.c
+++ b/sysdeps/nacl/getegid.c
@@ -19,18 +19,12 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <irt_syscalls.h> 
 
 /* Get the effective group ID of the calling process.  */
 gid_t
 __getegid ()
 {
-    static char firstcall = 1;
-    if(firstcall) {
-        firstcall = 0;
-        __set_errno(EAGAIN);
-        return -1;
-    }
-
     return (uid_t) __nacl_irt_getegid();
 }
 

--- a/sysdeps/nacl/geteuid.c
+++ b/sysdeps/nacl/geteuid.c
@@ -19,17 +19,12 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <irt_syscalls.h> 
 
 /* Get the effective user ID of the calling process.  */
 uid_t
 __geteuid ()
 {
-    static char firstcall = 1;
-    if(firstcall) {
-        firstcall = 0;
-        __set_errno(EAGAIN);
-        return -1;
-    }
     return (uid_t) __nacl_irt_geteuid();
 }
 

--- a/sysdeps/nacl/getgid.c
+++ b/sysdeps/nacl/getgid.c
@@ -19,17 +19,12 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <irt_syscalls.h> 
 
 /* Get the group ID of the calling process.  */
 gid_t
 __getgid ()
 {
-    static char firstcall = 1;
-    if(firstcall) {
-        firstcall = 0;
-        __set_errno(EAGAIN);
-        return -1;
-    }
     return (gid_t) __nacl_irt_getgid();
 }
 

--- a/sysdeps/nacl/getuid.c
+++ b/sysdeps/nacl/getuid.c
@@ -19,17 +19,12 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <irt_syscalls.h> 
 
 /* Get the real user ID of the calling process.  */
 uid_t
 __getuid ()
 {
-    static char firstcall = 1;
-    if(firstcall) {
-        firstcall = 0;
-        __set_errno(EAGAIN);
-        return -1;
-    }
     return (uid_t) __nacl_irt_getuid();
 }
 


### PR DESCRIPTION
Fixes get[e][g-u]id calls.