### PR TITLE
Added FIOASYNC option to ioctl

### DIFF
--- a/sysdeps/nacl/ioctl.c
+++ b/sysdeps/nacl/ioctl.c
@@ -23,6 +23,12 @@ int __ioctl (int fd, unsigned long request, ...) {
       instead of va_arg (ap, void *) for requests that directly accept 
       an arg value and not a pointer.*/
 
+    if (request == FIOASYNC) { //not implemented
+      printf("ioctl( .. , FIOASYNC, ...) was called. Just returning 0...\n");
+      //DO NOTHING
+      return 0;
+    }
+
     if (request == FIONBIO) {
       /* This command has a single void pointer as an arg, pointing to an integer*/
       va_list ap;

--- a/sysdeps/nacl/ioctl.c
+++ b/sysdeps/nacl/ioctl.c
@@ -23,13 +23,7 @@ int __ioctl (int fd, unsigned long request, ...) {
       instead of va_arg (ap, void *) for requests that directly accept 
       an arg value and not a pointer.*/
 
-    if (request == FIOASYNC) { //not implemented
-      printf("ioctl( .. , FIOASYNC, ...) was called. Just returning 0...\n");
-      //DO NOTHING
-      return 0;
-    }
-
-    if (request == FIONBIO) {
+    if (request == FIONBIO || request == FIOASYNC) {
       /* This command has a single void pointer as an arg, pointing to an integer*/
       va_list ap;
       va_start (ap, request);


### PR DESCRIPTION
With this update, FIOASYNC will be treated as a valid option for IOCTL and will be passed down to NaCl.