### PR TITLE
Fixed libc errno returns

### DIFF
--- a/sysdeps/nacl/access.c
+++ b/sysdeps/nacl/access.c
@@ -21,7 +21,7 @@ __access (const char* file, int type)
     __set_errno (-return_code);
     return -1;
   }
-  return return_code;
+  return 0;
 }
 
 weak_alias (__access, access)

--- a/sysdeps/nacl/close.c
+++ b/sysdeps/nacl/close.c
@@ -8,11 +8,11 @@
 int __close (int fd)
 {
   int result = __nacl_irt_close (fd);
-  if (result != 0) {
-    errno = result;
+  if (result < 0) {
+    __set_errno(-result);
     return -1;
   }
-  return -result;
+  return 0;
 }
 libc_hidden_def (__close)
 weak_alias (__close, close)

--- a/sysdeps/nacl/fstatfs.c
+++ b/sysdeps/nacl/fstatfs.c
@@ -15,7 +15,7 @@ __fstatfs (int fd, struct statfs *buf)
     __set_errno (-lind_rc);
      return -1;
   }
-   return lind_rc;
+   return 0;
 }
 
 weak_alias (__fstatfs, fstatfs)

--- a/sysdeps/nacl/ftruncate.c
+++ b/sysdeps/nacl/ftruncate.c
@@ -8,8 +8,8 @@
 ssize_t __ftruncate (int fd, off_t length)
 {
   int result = __nacl_irt_ftruncate (fd, length);
-  if (result != 0) {
-    errno = result;
+  if (result < 0) {
+    __set_errno(-result);
     return -1;
   }
   return 0;

--- a/sysdeps/nacl/fxstat.c
+++ b/sysdeps/nacl/fxstat.c
@@ -36,12 +36,12 @@ int __fxstat (int vers, int fd, struct stat *buf)
   }
   struct nacl_abi_stat nacl_buf;
   int result = __nacl_irt_fstat (fd, &nacl_buf);
-  if (result != 0) {
-    errno = result;
+  if (result < 0) {
+    __set_errno(-result);
     return -1;
   }
   __nacl_abi_stat_to_stat (&nacl_buf, buf);
-  return -result;
+  return 0;
 }
 hidden_def(__fxstat)
 #ifdef SHARED

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -62,7 +62,7 @@ static int nacl_irt_open (const char *pathname, int oflag, mode_t cmode) {
 }
 
 static int nacl_irt_close (int fd) {
-  return -NACL_SYSCALL (close) (fd);
+  return NACL_SYSCALL (close) (fd);
 }
 
 
@@ -131,7 +131,7 @@ static int nacl_irt_dup3 (int oldfd, int newfd, int flags) {
 }
 
 static int nacl_irt_fstat (int fd, struct nacl_abi_stat *st) {
-  return -NACL_SYSCALL (fstat) (fd, st);
+  return NACL_SYSCALL (fstat) (fd, st);
 }
 
 static int nacl_irt_fstatfs (int fd, struct statfs *buf) {
@@ -143,11 +143,11 @@ static int nacl_irt_statfs (const char* path, struct statfs *buf) {
 }
 
 static int nacl_irt_stat (const char *pathname, struct nacl_abi_stat *st) {
-  return -NACL_SYSCALL (stat) (pathname, st);
+  return NACL_SYSCALL (stat) (pathname, st);
 }
 
 static int nacl_irt_lstat (const char *pathname, struct nacl_abi_stat *st) {
-  return -NACL_SYSCALL (lstat) (pathname, st);
+  return NACL_SYSCALL (lstat) (pathname, st);
 }
 
 static int nacl_irt_access (const char *file, int mode) {

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -420,18 +420,16 @@ int (*__nacl_irt_getdents) (int fd, struct dirent *, size_t count,
 int (*__nacl_irt_access) (const char *file, int mode);
 int (*__nacl_irt_truncate) (const char *path, off_t length);
 int (*__nacl_irt_ftruncate) (int fd, off_t length);
-int (*__nacl_irt_socket) (int domain, int type, int protocol, int *sd);
+int (*__nacl_irt_socket) (int domain, int type, int protocol);
 int (*__nacl_irt_accept) (int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 int (*__nacl_irt_bind) (int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 int (*__nacl_irt_listen) (int sockfd, int backlog);
 int (*__nacl_irt_connect) (int sockfd, const struct sockaddr *addr,
                            socklen_t addrlen);
-int (*__nacl_irt_send) (int sockfd, const void *buf, size_t len, int flags,
-                        int *count);
+int (*__nacl_irt_send) (int sockfd, const void *buf, size_t len, int flags);
 int (*__nacl_irt_sendto) (int sockfd, const void *buf, size_t len, int flags,
-                          const struct sockaddr *dest_addr, socklen_t addrlen,
-                          int *count);
-int (*__nacl_irt_recv) (int sockfd, void *buf, size_t len, int flags, int *count);
+                          const struct sockaddr *dest_addr, socklen_t addrlen);
+int (*__nacl_irt_recv) (int sockfd, void *buf, size_t len, int flags);
 int (*__nacl_irt_recvfrom) (int sockfd, void *buf, size_t len, int flags,
                             struct sockaddr *dest_addr, socklen_t* addrlen, int *count);
 
@@ -587,13 +585,9 @@ static int nacl_irt_select_lind (int nfds, fd_set *readfds,
     return NACL_SYSCALL (select) (nfds, readfds, writefds, exceptfds, timeout);
 }
 
-static int nacl_irt_socket_lind (int domain, int type, int protocol, int *sd)
+static int nacl_irt_socket_lind (int domain, int type, int protocol)
 {
-    int rv = NACL_SYSCALL (socket) (domain, type, protocol);
-    if (rv < 0)
-        return -rv;
-    *sd=rv;
-    return 0;
+    return NACL_SYSCALL (socket) (domain, type, protocol);
 }
 
 static int nacl_irt_accept (int sockfd, struct sockaddr *addr, socklen_t *addrlen)
@@ -603,59 +597,33 @@ static int nacl_irt_accept (int sockfd, struct sockaddr *addr, socklen_t *addrle
 
 static int nacl_irt_bind (int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
-    int rv = NACL_SYSCALL (bind) (sockfd, addr, addrlen);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (bind) (sockfd, addr, addrlen);
 }
 
 static int nacl_irt_listen (int sockfd, int backlog)
 {
-    int rv = NACL_SYSCALL (listen) (sockfd, backlog);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (listen) (sockfd, backlog);
 }
 
 static int nacl_irt_connect (int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
-    int rv = NACL_SYSCALL (connect) (sockfd, addr, addrlen);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (connect) (sockfd, addr, addrlen);
 }
 
-static int nacl_irt_send(int sockfd, const void *buf, size_t len, int flags,
-                        int *count)
+static int nacl_irt_send(int sockfd, const void *buf, size_t len, int flags)
 {
-    int rv = NACL_SYSCALL (send) (sockfd, len, flags, buf);
-    if (rv < 0)
-        return -rv;
-    if(count)
-        *count = rv;
-    return 0;
+    return NACL_SYSCALL (send) (sockfd, len, flags, buf);
 }
 
-static int nacl_irt_recv(int sockfd, void *buf, size_t len, int flags, int *count)
+static int nacl_irt_recv(int sockfd, void *buf, size_t len, int flags)
 {
-    int rv = NACL_SYSCALL (recv) (sockfd, len, flags, buf);
-    if (rv < 0)
-        return -rv;
-    if(count)
-        *count = rv;
-    return 0;
+    return NACL_SYSCALL (recv) (sockfd, len, flags, buf);
 }
 
 static int nacl_irt_sendto(int sockfd, const void *buf, size_t len, int flags,
-                          const struct sockaddr *dest_addr, socklen_t addrlen,
-                          int *count)
+                          const struct sockaddr *dest_addr, socklen_t addrlen)
 {
-    int rv = NACL_SYSCALL (sendto) (sockfd, buf, len, flags, dest_addr, addrlen);
-    if (rv < 0)
-        return -rv;
-    if(count)
-        *count = rv;
-    return 0;
+    return NACL_SYSCALL (sendto) (sockfd, buf, len, flags, dest_addr, addrlen);
 }
 
 static int nacl_irt_recvfrom(int sockfd, void *buf, size_t len, int flags,

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -31,7 +31,7 @@ static int nacl_irt_unlink (const char *name) {
 }
 
 static int nacl_irt_rename(const char *oldpath, const char *newpath) {
-  return -NACL_SYSCALL (rename) (oldpath, newpath);
+  return NACL_SYSCALL (rename) (oldpath, newpath);
 }
 
 static int nacl_irt_gettod (struct timeval *tv) {
@@ -135,11 +135,11 @@ static int nacl_irt_fstat (int fd, struct nacl_abi_stat *st) {
 }
 
 static int nacl_irt_fstatfs (int fd, struct statfs *buf) {
-  return -NACL_SYSCALL (fstatfs) (fd, buf);
+  return NACL_SYSCALL (fstatfs) (fd, buf);
 }
 
 static int nacl_irt_statfs (const char* path, struct statfs *buf) {
-  return -NACL_SYSCALL (statfs) (path, buf);
+  return NACL_SYSCALL (statfs) (path, buf);
 }
 
 static int nacl_irt_stat (const char *pathname, struct nacl_abi_stat *st) {
@@ -151,7 +151,7 @@ static int nacl_irt_lstat (const char *pathname, struct nacl_abi_stat *st) {
 }
 
 static int nacl_irt_access (const char *file, int mode) {
-  return -NACL_SYSCALL (access) (file, mode);
+  return NACL_SYSCALL (access) (file, mode);
 }
 
 static int nacl_irt_getdents (int fd, struct dirent *buf, size_t count,
@@ -529,18 +529,12 @@ size_t (*saved_nacl_irt_query)(const char *interface_ident, void *table, size_t 
 
 static int nacl_irt_mkdir (const char *pathname, mode_t mode)
 {
-    int rv = NACL_SYSCALL (mkdir) (pathname, mode);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (mkdir) (pathname, mode);
 }
 
 static int nacl_irt_rmdir (const char *pathname)
 {
-    int rv = NACL_SYSCALL (rmdir) (pathname);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (rmdir) (pathname);
 }
 
 static int nacl_irt_chdir (const char *pathname)
@@ -816,17 +810,11 @@ static int nacl_irt_flock (int fd, int operation)
 
 static int nacl_irt_truncate (const char *path, off_t length)
 {
-    int rv = NACL_SYSCALL (truncate) (path, length);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (truncate) (path, length);
 }
 static int nacl_irt_ftruncate (int fd, off_t length)
 {
-    int rv = NACL_SYSCALL (ftruncate) (fd, length);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (ftruncate) (fd, length);
 }
 
 void

--- a/sysdeps/nacl/irt_syscalls.h
+++ b/sysdeps/nacl/irt_syscalls.h
@@ -71,7 +71,7 @@ extern int (*__nacl_irt_poll) (struct pollfd *fds, nfds_t nfds,
 extern int (*__nacl_irt_ppoll) (struct pollfd *fds, nfds_t nfds,
             const struct timespec *timeout, const sigset_t *sigmask,
             size_t sigset_size, int *count);
-extern int (*__nacl_irt_socket) (int domain, int type, int protocol, int *sd);
+extern int (*__nacl_irt_socket) (int domain, int type, int protocol);
 extern int (*__nacl_irt_accept) (int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 extern int (*__nacl_irt_bind) (int sockfd, const struct sockaddr *addr,
                                socklen_t addrlen);
@@ -79,12 +79,10 @@ extern int (*__nacl_irt_listen) (int sockfd, int backlog);
 extern int (*__nacl_irt_connect) (int sockfd, const struct sockaddr *addr,
                                   socklen_t addrlen);
 extern int (*__nacl_irt_send) (int sockfd, const void *buf, size_t len,
-                               int flags, int *count);
+                               int flags);
 extern int (*__nacl_irt_sendto) (int sockfd, const void *buf, size_t len,
-            int flags, const struct sockaddr *dest_addr, socklen_t addrlen,
-            int *count);
-extern int (*__nacl_irt_recv) (int sockfd, void *buf, size_t len, int flags,
-                               int *count);
+            int flags, const struct sockaddr *dest_addr, socklen_t addrlen);
+extern int (*__nacl_irt_recv) (int sockfd, void *buf, size_t len, int flags);
 extern int (*__nacl_irt_recvfrom) (int sockfd, void *buf, size_t len, int flags,
             struct sockaddr *dest_addr, socklen_t* addrlen, int *count);
 extern int (*__nacl_irt_select) (int nfds, fd_set *readfds,

--- a/sysdeps/nacl/lxstat.c
+++ b/sysdeps/nacl/lxstat.c
@@ -10,9 +10,9 @@ int __lxstat (int vers, const char *path, struct stat *buf)
     }
   struct nacl_abi_stat st;
   int result = __nacl_irt_lstat (path, &st);
-  if (result != 0)
+  if (result < 0)
     {
-      errno = result;
+      __set_errno(-result);
       return -1;
     }
   else

--- a/sysdeps/nacl/statfs.c
+++ b/sysdeps/nacl/statfs.c
@@ -29,10 +29,10 @@ __statfs (const char *file, struct statfs *buf)
   int result;
   result = __nacl_irt_statfs(file, buf);
   if (result < 0) {
-    errno = -result;
-    result = -1;
+    __set_errno(-result);
+    return -1;
   }
-  return result;
+  return 0;
 
 }
 libc_hidden_def (__statfs)

--- a/sysdeps/nacl/sysdep.h
+++ b/sysdeps/nacl/sysdep.h
@@ -1767,8 +1767,11 @@ __extern_always_inline int
 INTERNAL_SYSCALL_socket_3 (int *err, int domain, int type, int protocol)
 {
   int sd;
-  *err = __nacl_irt_socket (domain, type, protocol, &sd);
-  return sd;
+  sd = __nacl_irt_socket (domain, type, protocol);
+  if(sd < 0) {
+    *err = -sd;
+    return -1;
+  } else { return sd; }
 }
 
 __extern_always_inline int
@@ -1787,8 +1790,11 @@ __extern_always_inline int
 INTERNAL_SYSCALL_bind_3 (int *err, int sockfd, struct sockaddr* addr,
                          socklen_t addr_len)
 {
-  *err = __nacl_irt_bind (sockfd, addr, addr_len);
-  return 0;
+  int rv = __nacl_irt_bind (sockfd, addr, addr_len);
+  if(rv < 0) {
+    *err = -rv;
+    return -1;
+  } else { return 0; }
 }
 
 __extern_always_inline int
@@ -1826,16 +1832,22 @@ INTERNAL_SYSCALL_setsockopt_5 (int *err, int sockfd, int level, int optname,
 __extern_always_inline int
 INTERNAL_SYSCALL_listen_2 (int *err, int sockfd, int backlog)
 {
-  *err = __nacl_irt_listen (sockfd, backlog);
-  return 0;
+  int rv = __nacl_irt_listen (sockfd, backlog);
+  if( rv < 0 ){
+    *err = -rv;
+    return -1;
+  } else { return 0; }
 }
 
 __extern_always_inline int
 INTERNAL_SYSCALL_connect_3 (int *err, int sockfd, struct sockaddr* addr,
                             socklen_t addr_len)
 {
-  *err = __nacl_irt_connect (sockfd, addr, addr_len);
-  return 0;
+  int rv = __nacl_irt_connect (sockfd, addr, addr_len);
+  if(rv < 0) {
+    *err = -rv;
+    return -1;
+  } else { return 0; }
 }
 
 __extern_always_inline int
@@ -1856,8 +1868,11 @@ INTERNAL_SYSCALL_shutdown_2 (int *err, int sockfd, int how)
 __extern_always_inline int
 INTERNAL_SYSCALL_send_4 (int *err, int sockfd, const void *buf, size_t len, int flags)
 {
-  int ret;
-  *err = __nacl_irt_send (sockfd, buf, len, flags, &ret);
+  int ret = __nacl_irt_send (sockfd, buf, len, flags);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return ret;
 }
 
@@ -1866,16 +1881,21 @@ INTERNAL_SYSCALL_sendto_6 (int *err, int sockfd, const void *buf, size_t len,
                            int flags, const struct sockaddr *dest_addr,
 						   socklen_t addrlen)
 {
-  int ret;
-  *err = __nacl_irt_sendto (sockfd, buf, len, flags, dest_addr, addrlen, &ret);
-  return ret;
+  int ret = __nacl_irt_sendto (sockfd, buf, len, flags, dest_addr, addrlen);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  } else { return 0; }
 }
 
 __extern_always_inline int
 INTERNAL_SYSCALL_recv_4 (int *err, int sockfd, void *buf, size_t len, int flags)
 {
-  int ret;
-  *err = __nacl_irt_recv (sockfd, buf, len, flags, &ret);
+  int ret = __nacl_irt_recv (sockfd, buf, len, flags);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return ret;
 }
 

--- a/sysdeps/nacl/sysdep.h
+++ b/sysdeps/nacl/sysdep.h
@@ -966,7 +966,12 @@ INTERNAL_SYSCALL_mincore_3 (int *err, void *addr, size_t length,
 __extern_always_inline int
 INTERNAL_SYSCALL_mkdir_2 (int *err, const char *pathname, mode_t mode)
 {
-  *err = __nacl_irt_mkdir (pathname, mode);
+  int ret;
+  ret = __nacl_irt_mkdir (pathname, mode);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return 0;
 }
 
@@ -1393,7 +1398,12 @@ INTERNAL_SYSCALL_renameat_4 (int *err, int olddfd, const char *oldname,
 __extern_always_inline int
 INTERNAL_SYSCALL_rmdir_1 (int *err, const char *pathname)
 {
-  *err = __nacl_irt_rmdir (pathname);
+  int ret;
+  ret = __nacl_irt_rmdir (pathname);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return 0;
 }
 

--- a/sysdeps/nacl/truncate.c
+++ b/sysdeps/nacl/truncate.c
@@ -8,8 +8,8 @@
 ssize_t __truncate (const char *path, off_t length)
 {
   int result = __nacl_irt_truncate (path, length);
-  if (result != 0) {
-    errno = result;
+  if (result < 0) {
+    __set_errno(-result);
     return -1;
   }
   return 0;

--- a/sysdeps/nacl/xstat.c
+++ b/sysdeps/nacl/xstat.c
@@ -16,7 +16,7 @@ int __xstat (int version, const char *path, struct stat *buf)
   int result = __nacl_irt_stat (path, &st);
   if (result != 0)
     {
-      errno = result;
+      __set_errno(-result);
       return -1;
     }
   else


### PR DESCRIPTION
  ## Description

Fixes [#317](https://github.com/Lind-Project/lind_project/issues/317)

Fixed problems with return values especially when syscall failed (errno related).
- socket
- bind
- listen
- connect
- send/sendto
- recv
- rename
- mkdir/rmdir
- close
- stat/fstat/lstat
- statfs/fstatfs
- access
- truncate/ftruncate

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Corresponding test are in branch `test-sigprocmask` in Lind-Project/tests/testcases, and in format: testX.c for test of X. 

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-project, safeposix-rust)
