### PR TITLE
Fix libc errno returns

### DIFF
--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -683,10 +683,7 @@ static int nacl_irt_socketpair_lind (int domain, int type, int protocol, int sv[
 static int nacl_irt_getpeername (int sockfd, struct sockaddr *addr,
                                socklen_t *addrlen)
 {
-    int rv = NACL_SYSCALL(getpeername) (sockfd, addr, addrlen);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL(getpeername) (sockfd, addr, addrlen);
 }
 
 static int nacl_irt_getsockname (int sockfd, struct sockaddr *addr,

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -441,7 +441,7 @@ int (*__nacl_irt_epoll_pwait) (int epfd, struct epoll_event *events,
     int maxevents, int timeout, const sigset_t *sigmask, size_t sigset_size,
     int *count);
 int (*__nacl_irt_epoll_wait) (int epfd, struct epoll_event *events,
-                                int maxevents, int timeout, int *count);
+                                int maxevents, int timeout);
 int (*__nacl_irt_poll) (struct pollfd *fds, nfds_t nfds,
                           int timeout);
 int (*__nacl_irt_ppoll) (struct pollfd *fds, nfds_t nfds,
@@ -705,26 +705,18 @@ static int nacl_irt_poll_lind (struct pollfd *fds, nfds_t nfds, int timeout)
 
 static int nacl_irt_epoll_create_lind (int size, int *fd)
 {
-    int rv = NACL_SYSCALL (epoll_create)(size);
-    if (rv < 0)
-        return -rv;
-    *fd = rv;
-    return 0;
+    return NACL_SYSCALL (epoll_create)(size);
 }
 
 static int nacl_irt_epoll_ctl_lind (int epfd, int op, int fd, struct epoll_event *event)
 {
-    return -NACL_SYSCALL (epoll_ctl)(epfd, op, fd, event);
+    return NACL_SYSCALL (epoll_ctl)(epfd, op, fd, event);
 }
 
 static int nacl_irt_epoll_wait_lind (int epfd, struct epoll_event *events,
-                                 int maxevents, int timeout, int *count)
+                                 int maxevents, int timeout)
 {
-    int rv = NACL_SYSCALL (epoll_wait) (epfd, events, maxevents, timeout);
-    if (rv < 0)
-        return -rv;
-    *count = rv;
-    return 0;
+    return NACL_SYSCALL (epoll_wait) (epfd, events, maxevents, timeout);
 }
 
 static int nacl_irt_getcwd (char* buf, size_t size)

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -639,10 +639,7 @@ static int nacl_irt_recvfrom(int sockfd, void *buf, size_t len, int flags,
 
 static int nacl_irt_shutdown (int sockfd, int how)
 {
-    int rv = NACL_SYSCALL (shutdown) (sockfd,how);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (shutdown) (sockfd,how);
 }
 
 static int nacl_irt_getsockopt_lind (int sockfd, int level, int optname,
@@ -668,10 +665,7 @@ static int nacl_irt_setsockopt_lind (int sockfd, int level, int optname,
 
 static int nacl_irt_socketpair_lind (int domain, int type, int protocol, int sv[static 2])
 {
-    int rv = NACL_SYSCALL (socketpair) (domain, type, protocol, sv);
-    if ( rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (socketpair) (domain, type, protocol, sv);
 }
 
 static int nacl_irt_getpeername (int sockfd, struct sockaddr *addr,

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -433,7 +433,7 @@ int (*__nacl_irt_recv) (int sockfd, void *buf, size_t len, int flags);
 int (*__nacl_irt_recvfrom) (int sockfd, void *buf, size_t len, int flags,
                             struct sockaddr *dest_addr, socklen_t* addrlen, int *count);
 
-int (*__nacl_irt_epoll_create) (int size, int *fd);
+int (*__nacl_irt_epoll_create) (int size);
 int (*__nacl_irt_epoll_create1) (int flags, int *fd);
 int (*__nacl_irt_epoll_ctl) (int epfd, int op, int fd,
                              struct epoll_event *event);

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -654,10 +654,7 @@ static int nacl_irt_getsockopt_lind (int sockfd, int level, int optname,
         optlen = &bufsize;
     if(optval == NULL)
         optval = &buf;
-    int rv = NACL_SYSCALL (getsockopt) (sockfd, level, optname, optval, optlen);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (getsockopt) (sockfd, level, optname, optval, optlen);
 }
 
 static int nacl_irt_setsockopt_lind (int sockfd, int level, int optname,
@@ -666,10 +663,7 @@ static int nacl_irt_setsockopt_lind (int sockfd, int level, int optname,
     if (optlen > 0 && !optval)
         return EFAULT;
     int buf=0; //dummy, in case optval is no provided
-    int rv = NACL_SYSCALL (setsockopt) (sockfd, level, optname, optval?optval:&buf, optlen);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (setsockopt) (sockfd, level, optname, optval?optval:&buf, optlen);
 }
 
 static int nacl_irt_socketpair_lind (int domain, int type, int protocol, int sv[static 2])
@@ -689,10 +683,7 @@ static int nacl_irt_getpeername (int sockfd, struct sockaddr *addr,
 static int nacl_irt_getsockname (int sockfd, struct sockaddr *addr,
                                socklen_t *addrlen)
 {
-    int rv = NACL_SYSCALL (getsockname) (sockfd, addr, addrlen);
-    if (rv < 0)
-        return -rv;
-    return 0;
+    return NACL_SYSCALL (getsockname) (sockfd, addr, addrlen);
 }
 
 static int nacl_irt_poll_lind (struct pollfd *fds, nfds_t nfds, int timeout)

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -703,7 +703,7 @@ static int nacl_irt_poll_lind (struct pollfd *fds, nfds_t nfds, int timeout)
     return NACL_SYSCALL (poll) (fds, nfds, timeout);
 }
 
-static int nacl_irt_epoll_create_lind (int size, int *fd)
+static int nacl_irt_epoll_create_lind (int size)
 {
     return NACL_SYSCALL (epoll_create)(size);
 }

--- a/sysdeps/nacl/irt_syscalls.h
+++ b/sysdeps/nacl/irt_syscalls.h
@@ -65,7 +65,7 @@ extern int (*__nacl_irt_epoll_pwait) (int epfd, struct epoll_event *events,
             int maxevents, int timeout, const sigset_t *sigmask,
             size_t sigset_size, int *count);
 extern int (*__nacl_irt_epoll_wait) (int epfd, struct epoll_event *events,
-                                 int maxevents, int timeout, int *count);
+                                 int maxevents, int timeout);
 extern int (*__nacl_irt_poll) (struct pollfd *fds, nfds_t nfds,
                            int timeout);
 extern int (*__nacl_irt_ppoll) (struct pollfd *fds, nfds_t nfds,

--- a/sysdeps/nacl/irt_syscalls.h
+++ b/sysdeps/nacl/irt_syscalls.h
@@ -57,7 +57,7 @@ extern int (*__nacl_irt_fcntl_set) (int fd, int cmd, long set_op);
 
 extern int (*__nacl_irt_ioctl) (int fd, unsigned long request, void* arg_ptr);
 
-extern int (*__nacl_irt_epoll_create) (int size, int *fd);
+extern int (*__nacl_irt_epoll_create) (int size);
 extern int (*__nacl_irt_epoll_create1) (int flags, int *fd);
 extern int (*__nacl_irt_epoll_ctl) (int epfd, int op, int fd,
                                     struct epoll_event *event);

--- a/sysdeps/nacl/sysdep.h
+++ b/sysdeps/nacl/sysdep.h
@@ -246,7 +246,11 @@ __extern_always_inline int
 INTERNAL_SYSCALL_epoll_create_1 (int *err, int size)
 {
   int fd;
-  *err = __nacl_irt_epoll_create (size, &fd);
+  fd = __nacl_irt_epoll_create (size, &fd);
+  if(fd < 0) {
+    *err = -fd;
+    return -1;
+  }
   return fd;
 }
 
@@ -262,7 +266,11 @@ __extern_always_inline int
 INTERNAL_SYSCALL_epoll_ctl_4 (int *err, int epfd, int op, int fd,
 			      struct epoll_event *event)
 {
-  *err = __nacl_irt_epoll_ctl (epfd, op, fd, event);
+  int ret = __nacl_irt_epoll_ctl (epfd, op, fd, event);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return 0;
 }
 
@@ -290,9 +298,12 @@ __extern_always_inline int
 INTERNAL_SYSCALL_epoll_wait_4 (int *err, int epfd, struct epoll_event *events,
 			       int maxevents, int timeout)
 {
-  int count;
-  *err = __nacl_irt_epoll_wait (epfd, events, maxevents, timeout, &count);
-  return count;
+  int ret = __nacl_irt_epoll_wait (epfd, events, maxevents, timeout);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
+  return ret;
 }
 
 __extern_always_inline int

--- a/sysdeps/nacl/sysdep.h
+++ b/sysdeps/nacl/sysdep.h
@@ -1834,7 +1834,11 @@ __extern_always_inline int
 INTERNAL_SYSCALL_getsockname_3 (int *err, int sockfd, struct sockaddr* addr,
                                 socklen_t* addr_len)
 {
-  *err = __nacl_irt_getsockname (sockfd, addr, addr_len);
+  int ret = __nacl_irt_getsockname (sockfd, addr, addr_len);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return 0;
 }
 
@@ -1842,7 +1846,11 @@ __extern_always_inline int
 INTERNAL_SYSCALL_getsockopt_5 (int *err, int sockfd, int level, int optname,
                                void *optval, socklen_t *optlen)
 {
-  *err = __nacl_irt_getsockopt (sockfd, level, optname, optval, optlen);
+  int ret = __nacl_irt_getsockopt (sockfd, level, optname, optval, optlen);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return 0;
 }
 
@@ -1850,7 +1858,11 @@ __extern_always_inline int
 INTERNAL_SYSCALL_setsockopt_5 (int *err, int sockfd, int level, int optname,
                                const void *optval, socklen_t optlen)
 {
-  *err = __nacl_irt_setsockopt (sockfd, level, optname, optval, optlen);
+  int ret = __nacl_irt_setsockopt (sockfd, level, optname, optval, optlen);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return 0;
 }
 

--- a/sysdeps/nacl/sysdep.h
+++ b/sysdeps/nacl/sysdep.h
@@ -246,7 +246,7 @@ __extern_always_inline int
 INTERNAL_SYSCALL_epoll_create_1 (int *err, int size)
 {
   int fd;
-  fd = __nacl_irt_epoll_create (size, &fd);
+  fd = __nacl_irt_epoll_create (size);
   if(fd < 0) {
     *err = -fd;
     return -1;

--- a/sysdeps/nacl/sysdep.h
+++ b/sysdeps/nacl/sysdep.h
@@ -1891,14 +1891,22 @@ __extern_always_inline int
 INTERNAL_SYSCALL_socketpair_4 (int *err, int domain, int type, int protocol,
                              int sv[2])
 {
-  *err = __nacl_irt_socketpair (domain, type, protocol, sv);
+  int ret = __nacl_irt_socketpair (domain, type, protocol, sv);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return 0;
 }
 
 __extern_always_inline int
 INTERNAL_SYSCALL_shutdown_2 (int *err, int sockfd, int how)
 {
-  *err = __nacl_irt_shutdown (sockfd, how);
+  int ret = __nacl_irt_shutdown (sockfd, how);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
   return 0;
 }
 
@@ -1922,7 +1930,7 @@ INTERNAL_SYSCALL_sendto_6 (int *err, int sockfd, const void *buf, size_t len,
   if(ret < 0) {
     *err = -ret;
     return -1;
-  } else { return 0; }
+  } else { return ret; }
 }
 
 __extern_always_inline int

--- a/sysdeps/nacl/sysdep.h
+++ b/sysdeps/nacl/sysdep.h
@@ -1822,7 +1822,11 @@ __extern_always_inline int
 INTERNAL_SYSCALL_getpeername_3 (int *err, int sockfd, struct sockaddr* addr,
                                 socklen_t* addr_len)
 {
-  *err = __nacl_irt_getpeername (sockfd, addr, addr_len);
+  int rv = __nacl_irt_getpeername (sockfd, addr, addr_len);
+  if(rv < 0) {
+    *err = -rv;
+    return -1;
+  }
   return 0;
 }
 


### PR DESCRIPTION
  ## Description

Fixes [#317](https://github.com/Lind-Project/lind_project/issues/317)

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

Fixed problems with return values especially when syscall failed (errno related).
- epoll_create/epoll_wait/epoll_ctl
- getpeername
- getsockname
- getsockopt
- setsockopt
- sendto
- shutdown

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Corresponding test are in branch `test-sigprocmask` in Lind-Project/tests/testcases, and in format: testX.c for test of X. 

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-project, safeposix-rust)
