### PR TITLE
Fix libc errno returns

### DIFF
--- a/sysdeps/nacl/ifaddrs.c
+++ b/sysdeps/nacl/ifaddrs.c
@@ -84,7 +84,7 @@ getifaddrs (struct ifaddrs **ifap)
 
 	if (result < 0) {
 		free(buf);
-		errno = result;
+		__set_errno(-result);
 		return -1;
 	}
 

--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -77,45 +77,24 @@ static int nacl_irt_ioctl (int fd, unsigned long request, void* arg_ptr) {
   return NACL_SYSCALL (ioctl) (fd, request, arg_ptr);
 }
 
-static int nacl_irt_read (int fd, void *buf, size_t count, size_t *nread) {
-  int rv = NACL_SYSCALL (read) (fd, buf, count);
-  if (rv < 0)
-    return -rv;
-  *nread = rv;
-  return 0;
+static int nacl_irt_read (int fd, void *buf, size_t count) {
+  return NACL_SYSCALL (read) (fd, buf, count);
 }
 
-static int nacl_irt_pread (int fd, void *buf, size_t count, size_t *nread, off_t offset) {
-  int rv = NACL_SYSCALL (pread) (fd, buf, count, offset);
-  if (rv < 0)
-    return -rv;
-  *nread = rv;
-  return 0;
+static int nacl_irt_pread (int fd, void *buf, size_t count, off_t offset) {
+  return NACL_SYSCALL (pread) (fd, buf, count, offset);
 }
 
-static int nacl_irt_write (int fd, const void *buf, size_t count, size_t *nwrote) {
-  int rv = NACL_SYSCALL (write) (fd, buf, count);
-  if (rv < 0)
-    return -rv;
-  *nwrote = rv;
-  return 0;
+static int nacl_irt_write (int fd, const void *buf, size_t count) {
+  return NACL_SYSCALL (write) (fd, buf, count);
 }
 
-static int nacl_irt_pwrite (int fd, const void *buf, size_t count, size_t *nwrote, off_t offset) {
-  int rv = NACL_SYSCALL (pwrite) (fd, buf, count, offset);
-  if (rv < 0)
-    return -rv;
-  *nwrote = rv;
-  return 0;
+static int nacl_irt_pwrite (int fd, const void *buf, size_t count, off_t offset) {
+  return NACL_SYSCALL (pwrite) (fd, buf, count, offset);
 }
 
-static int nacl_irt_seek (int fd, nacl_abi_off_t offset, int whence,
-                          off_t *new_offset) {
-  int rv = NACL_SYSCALL (lseek) (fd, &offset, whence);
-  if (rv < 0)
-    return -rv;
-  *new_offset = offset;
-  return 0;
+static int nacl_irt_seek (int fd, nacl_abi_off_t offset, int whence) {
+  return NACL_SYSCALL (lseek) (fd, &offset, whence);
 }
 
 static int nacl_irt_dup (int oldfd) {
@@ -405,11 +384,11 @@ int (*__nacl_irt_ioctl) (int fd, unsigned long request, void* arg_ptr);
 
 int (*__nacl_irt_open) (const char *pathname, int oflag, mode_t cmode);
 int (*__nacl_irt_close) (int fd);
-int (*__nacl_irt_read) (int fd, void *buf, size_t count, size_t *nread);
-int (*__nacl_irt_pread) (int fd, void *buf, size_t count, size_t *nread, off_t offset);
-int (*__nacl_irt_write) (int fd, const void *buf, size_t count, size_t *nwrote);
-int (*__nacl_irt_pwrite) (int fd, const void *buf, size_t count, size_t *nwrote, off_t offset);
-int (*__nacl_irt_seek) (int fd, off_t offset, int whence, off_t *new_offset);
+int (*__nacl_irt_read) (int fd, void *buf, size_t count);
+int (*__nacl_irt_pread) (int fd, void *buf, size_t count, off_t offset);
+int (*__nacl_irt_write) (int fd, const void *buf, size_t count);
+int (*__nacl_irt_pwrite) (int fd, const void *buf, size_t count, off_t offset);
+int (*__nacl_irt_seek) (int fd, off_t offset, int whence);
 int (*__nacl_irt_fstat) (int fd, struct nacl_abi_stat *);
 int (*__nacl_irt_stat) (const char *pathname, struct nacl_abi_stat *);
 int (*__nacl_irt_fstatfs) (int fd, struct statfs *buf);

--- a/sysdeps/nacl/irt_syscalls.h
+++ b/sysdeps/nacl/irt_syscalls.h
@@ -107,15 +107,12 @@ extern int (*__nacl_irt_shutdown) (int sockfd, int how);
 extern int (*__nacl_irt_open) (const char *pathname, int oflag, mode_t cmode);
 
 extern int (*__nacl_irt_close) (int fd);
-extern int (*__nacl_irt_read) (int fd, void *buf, size_t count, size_t *nread);
-extern int (*__nacl_irt_write) (int fd, const void *buf, size_t count,
-                                size_t *nwrote);
-extern int (*__nacl_irt_pread) (int fd, void *buf, size_t count, size_t *nread, off_t offset);
-extern int (*__nacl_irt_pwrite) (int fd, const void *buf, size_t count,
-                                size_t *nwrote, off_t offset);
+extern int (*__nacl_irt_read) (int fd, void *buf, size_t count);
+extern int (*__nacl_irt_write) (int fd, const void *buf, size_t count);
+extern int (*__nacl_irt_pread) (int fd, void *buf, size_t count, off_t offset);
+extern int (*__nacl_irt_pwrite) (int fd, const void *buf, size_t count, off_t offset);
 
-extern int (*__nacl_irt_seek) (int fd, nacl_abi_off_t offset, int whence,
-                               nacl_abi_off_t *new_offset);
+extern int (*__nacl_irt_seek) (int fd, nacl_abi_off_t offset, int whence);
 extern int (*__nacl_irt_fstat) (int fd, struct nacl_abi_stat *);
 extern int (*__nacl_irt_stat) (const char *pathname, struct nacl_abi_stat *);
 extern int (*__nacl_irt_lstat) (const char *pathname, struct nacl_abi_stat *);

--- a/sysdeps/nacl/llseek.c
+++ b/sysdeps/nacl/llseek.c
@@ -6,10 +6,10 @@
 
 loff_t __llseek (int fd, loff_t offset, int whence)
 {
-  int result = __nacl_irt_seek (fd, offset, whence, &offset);
-  if (result != 0)
+  int result = __nacl_irt_seek (fd, offset, whence);
+  if (result < 0)
     {
-      errno = result;
+      __set_errno(-result);
       return -1;
     }
   return offset;

--- a/sysdeps/nacl/lseek.c
+++ b/sysdeps/nacl/lseek.c
@@ -8,9 +8,9 @@
 off_t __lseek (int fd, off_t offset, int whence)
 {
   nacl_abi_off_t nacl_offset = offset;
-  int result = __nacl_irt_seek (fd, nacl_offset, whence, &nacl_offset);
-  if (result != 0) {
-    errno = result;
+  int result = __nacl_irt_seek (fd, nacl_offset, whence);
+  if (result < 0) {
+    __set_errno(-result);
     return -1;
   }
   return nacl_offset;

--- a/sysdeps/nacl/pread.c
+++ b/sysdeps/nacl/pread.c
@@ -7,13 +7,12 @@
 
 ssize_t __pread (int fd, void *buf, size_t size, off_t offset)
 {
-  size_t nread;
-  int result = __nacl_irt_pread (fd, buf, size, &nread, offset);
-  if (result != 0) {
-    errno = result;
+  int result = __nacl_irt_pread (fd, buf, size, offset);
+  if (result < 0) {
+    __set_errno(-result);
     return -1;
   }
-  return nread;
+  return result;
 }
 
 weak_alias (__pread, pread)

--- a/sysdeps/nacl/pwrite.c
+++ b/sysdeps/nacl/pwrite.c
@@ -7,13 +7,12 @@
 
 ssize_t __pwrite(int desc, void const *buf, size_t count, off_t offset)
 {
-  size_t nwrite;
-  int result = __nacl_irt_pwrite (desc, buf, count, &nwrite, offset);
-  if (result != 0) {
-    errno = result;
+  int result = __nacl_irt_pwrite (desc, buf, count, offset);
+  if (result < 0) {
+    __set_errno(-result);
     return -1;
   }
-  return nwrite;
+  return result;
 }
 
 weak_alias (__pwrite, pwrite)

--- a/sysdeps/nacl/read.c
+++ b/sysdeps/nacl/read.c
@@ -8,13 +8,12 @@
 
 ssize_t __libc_read (int fd, void *buf, size_t size)
 {
-  size_t nread;
-  int result = __nacl_irt_read (fd, buf, size, &nread);
-  if (result != 0) {
-    errno = result;
+  int result = __nacl_irt_read (fd, buf, size);
+  if (result < 0) {
+    __set_errno(-result);
     return -1;
   }
-  return nread;
+  return result;
 }
 libc_hidden_def (__libc_read)
 weak_alias (__libc_read, __read)

--- a/sysdeps/nacl/sysdep.h
+++ b/sysdeps/nacl/sysdep.h
@@ -2334,9 +2334,12 @@ INTERNAL_SYSCALL_wait4_4 (int *err, pid_t pid, int *status, int options,
 __extern_always_inline ssize_t
 INTERNAL_SYSCALL_write_3 (int *err, int fd, const void *buf, size_t count)
 {
-  size_t nwrote;
-  *err = __nacl_irt_write (fd, buf, count, &nwrote);
-  return nwrote;
+  int ret = __nacl_irt_write (fd, buf, count);
+  if(ret < 0) {
+    *err = -ret;
+    return -1;
+  }
+  return ret;
 }
 
 __extern_always_inline ssize_t

--- a/sysdeps/nacl/write.c
+++ b/sysdeps/nacl/write.c
@@ -7,13 +7,12 @@
 
 ssize_t __write(int desc, void const *buf, size_t count)
 {
-  size_t nwrite;
-  int result = __nacl_irt_write (desc, buf, count, &nwrite);
-  if (result != 0) {
-    errno = result;
+  int result = __nacl_irt_write (desc, buf, count);
+  if (result < 0) {
+    __set_errno(-result);
     return -1;
   }
-  return nwrite;
+  return result;
 }
 libc_hidden_def (__write)
 weak_alias (__write, write)


### PR DESCRIPTION
  ## Description

Fixes [#317](https://github.com/Lind-Project/lind_project/issues/317)

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

Fixed problems with return values especially when syscall failed (errno related).
- read/pread
- write/pwrite
- seek

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Corresponding test are in branch `test-sigprocmask` in Lind-Project/tests/testcases, and in format: testX.c for test of X. 

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-project, safeposix-rust)
