### PR TITLE
Fix shmctl error return

### DIFF
--- a/sysdeps/nacl/shmctl.c
+++ b/sysdeps/nacl/shmctl.c
@@ -32,6 +32,10 @@ int __shmctl (int shmid, int cmd, struct shmid_ds *buf) {
     struct nacl_abi_shmid_ds nacl_buf;
 
     if (cmd == IPC_STAT)  {
+      if (buf == NULL) {
+        __set_errno (14);
+        return -1;
+      }
       result = __nacl_irt_shmctl(shmid, cmd, &nacl_buf);
       __nacl_abi_shmidstat_to_shmidstat(&nacl_buf, buf);
     } else {

--- a/sysdeps/nacl/shmctl.c
+++ b/sysdeps/nacl/shmctl.c
@@ -32,7 +32,7 @@ int __shmctl (int shmid, int cmd, struct shmid_ds *buf) {
     struct nacl_abi_shmid_ds nacl_buf;
 
     if (cmd == IPC_STAT)  {
-      if (&nacl_buf == NULL) {
+      if (buf == NULL) {
         __set_errno (14);
         return -1;
       }

--- a/sysdeps/nacl/shmctl.c
+++ b/sysdeps/nacl/shmctl.c
@@ -33,10 +33,8 @@ int __shmctl (int shmid, int cmd, struct shmid_ds *buf) {
     struct nacl_abi_shmid_ds nacl_buf;
 
     if (cmd == IPC_STAT)  {
-      printf("%p:\n", buf);
-      fflush(stdout);
       if (buf == NULL) {
-        __set_errno (14);
+        __set_errno (EFAULT);
         return -1;
       }
       result = __nacl_irt_shmctl(shmid, cmd, &nacl_buf);

--- a/sysdeps/nacl/shmctl.c
+++ b/sysdeps/nacl/shmctl.c
@@ -1,5 +1,6 @@
 #include <sys/shm.h>
 #include <errno.h>
+#include <stdio.h>
 
 #include <nacl_stat.h>
 #include <irt_syscalls.h>
@@ -32,6 +33,8 @@ int __shmctl (int shmid, int cmd, struct shmid_ds *buf) {
     struct nacl_abi_shmid_ds nacl_buf;
 
     if (cmd == IPC_STAT)  {
+      printf("%p:\n", buf);
+      fflush(stdout);
       if (buf == NULL) {
         __set_errno (14);
         return -1;

--- a/sysdeps/nacl/shmctl.c
+++ b/sysdeps/nacl/shmctl.c
@@ -32,7 +32,7 @@ int __shmctl (int shmid, int cmd, struct shmid_ds *buf) {
     struct nacl_abi_shmid_ds nacl_buf;
 
     if (cmd == IPC_STAT)  {
-      if (buf == NULL) {
+      if (&nacl_buf == NULL) {
         __set_errno (14);
         return -1;
       }

--- a/sysdeps/nacl/shmctl.c
+++ b/sysdeps/nacl/shmctl.c
@@ -1,6 +1,5 @@
 #include <sys/shm.h>
 #include <errno.h>
-#include <stdio.h>
 
 #include <nacl_stat.h>
 #include <irt_syscalls.h>


### PR DESCRIPTION
  ## Description

Fixes [#317](https://github.com/Lind-Project/lind_project/issues/317)

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

As `cmd` is set to `IPC_STAT`, `shmctl` should return errno=EFAULT when the address pointed to by `buf` isn't accessible.
Before modification, lind will display `*** signal 11...`, and after repair, it will return to err=14 normally.
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run `/lind/lind_project/tests/testcases/testshmctl.c`

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->


## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-project, safeposix-rust)
