### PR TITLE
Fix libc errno returns

### DIFF
--- a/sysdeps/nacl/irt_syscalls.c
+++ b/sysdeps/nacl/irt_syscalls.c
@@ -177,7 +177,7 @@ static int nacl_irt_shmat (int shmid, void **shmaddr, int shmflg) {
 }
 
 static int nacl_irt_shmdt (void *shmaddr) {
-  return -NACL_SYSCALL (shmdt) (shmaddr);
+  return NACL_SYSCALL (shmdt) (shmaddr);
 }
 
 static int nacl_irt_shmctl (int shmid, int cmd, struct nacl_abi_shmid_ds *buf) {
@@ -195,11 +195,11 @@ static int nacl_irt_mmap (void **addr, size_t len,
 }
 
 static int nacl_irt_munmap (void *addr, size_t len) {
-  return -NACL_SYSCALL (munmap) (addr, len);
+  return NACL_SYSCALL (munmap) (addr, len);
 }
 
 static int nacl_irt_mprotect (void *addr, size_t len, int prot) {
-  return -NACL_SYSCALL (mprotect) (addr, len, prot);
+  return NACL_SYSCALL (mprotect) (addr, len, prot);
 }
 
 static int nacl_irt_dyncode_create(void *dest, const void *src, size_t size) {

--- a/sysdeps/nacl/mprotect.c
+++ b/sysdeps/nacl/mprotect.c
@@ -9,7 +9,7 @@ int __mprotect (void *addr, size_t len, int prot)
 {
   int result = __nacl_irt_mprotect (addr, len, prot);
   if (result != 0) {
-    errno = result;
+    __set_errno(-result);
     return -1;
   }
   return 0;

--- a/sysdeps/nacl/munmap.c
+++ b/sysdeps/nacl/munmap.c
@@ -9,7 +9,7 @@ int __munmap (void *start, size_t length)
 {
   int result = __nacl_irt_munmap (start, length);
   if (result != 0) {
-    errno = result;
+    __set_errno(-result);
     return -1;
   }
   return 0;

--- a/sysdeps/nacl/shmdt.c
+++ b/sysdeps/nacl/shmdt.c
@@ -13,7 +13,7 @@ int __shmdt (const void *shmaddr) {
 
     result = __nacl_irt_shmdt(shmaddr);
     if (result != 0) {
-      errno = result;
+      __set_errno(-result);
       return -1;
     }
 


### PR DESCRIPTION
  ## Description

Fixes [#317](https://github.com/Lind-Project/lind_project/issues/317)
<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

Fixed problems with return values especially when syscall failed (errno related).
- shmdt
- munmap
- mprotect
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Corresponding test are in branch `test-sigprocmask` in `Lind-Project/tests/testcases`, and in format: testX.c for test of X.

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-project, safeposix-rust)
