### PR TITLE
PR Summary: Fix Duplicate Output from fork()

### DIFF
--- a/sysdeps/nacl/exit-thread.c
+++ b/sysdeps/nacl/exit-thread.c
@@ -2,9 +2,18 @@
 #include <irt_syscalls.h>
 #include <nptl/pthreadP.h>
 #include <unistd.h>
+#include <stdio.h>
 
 void __exit_thread (int val)
 {
+  /*
+      * The NaCl IRT fork function copies the process memory as a whole to the child, so we need to
+      * flush the stdio buffers before calling it.
+      * Issue #12:https://github.com/Lind-Project/native_client/issues/12
+  */
+  fflush(stdout);
+  fflush(stderr);
+
   /* We are about to die: make our pd "almost free" and wake up waiter. */
   struct pthread* pd = THREAD_SELF;
   int count;

--- a/sysdeps/nacl/fork.c
+++ b/sysdeps/nacl/fork.c
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sysdep.h>
+#include <stdio.h>
 
 unsigned long int *__fork_generation_pointer;
 
@@ -11,6 +12,14 @@ unsigned long int *__fork_generation_pointer;
  */
 int __libc_fork(void)
 {
+   /*
+      * The NaCl IRT fork function copies the process memory as a whole to the child, so we need to
+      * flush the stdio buffers before calling it.
+      * Issue #12:https://github.com/Lind-Project/native_client/issues/12
+   */
+   fflush(stdout);
+   fflush(stderr);
+   
    int ret = __nacl_irt_fork();
    if (!ret && __fork_generation_pointer)
       *__fork_generation_pointer += 4;


### PR DESCRIPTION

This PR addresses an issue where the output from a program using the fork() system call was duplicated, resulting in unintended output. The problem was due to both the parent and child processes having the same iO buffers causing both to print to the standard output.

To resolve this, the following changes were made:

* Added fflush(stdout); before the fork() call to ensure that the buffer is flushed, preventing any buffered output from being duplicated in the child process.

* With these changes, the program now produces the correct and intended output, ensuring only the parent process prints "2!" while the child process exits immediately.

Issue link: https://github.com/Lind-Project/native_client/issues/12